### PR TITLE
fix stdin handling

### DIFF
--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -48,7 +48,7 @@ class BuiltinsChecker(object):
         tree = self.tree
 
         if self.filename == 'stdin':
-            lines = stdin_utils.stdin_get_value().splitlines(True)
+            lines = stdin_utils.stdin_get_value()
             tree = ast.parse(lines)
 
         for statement in ast.walk(self.tree):

--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -51,7 +51,7 @@ class BuiltinsChecker(object):
             lines = stdin_utils.stdin_get_value()
             tree = ast.parse(lines)
 
-        for statement in ast.walk(self.tree):
+        for statement in ast.walk(tree):
             value = None
             if isinstance(statement, ast.Assign):
                 value = self.check_assignment(statement)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from flake8_builtins import BuiltinsChecker
+from io import BytesIO, StringIO
 
 import ast
+import sys
 import unittest
 
 
@@ -125,6 +127,21 @@ class TestBuiltins(unittest.TestCase):
             0
         )
 
+    def test_stdin(self):
+        code = u'max = 4'
+        stdin_ = sys.stdin
+        if sys.version_info < (3, 0):
+            sys.stdin = BytesIO(code.encode('utf-8'))
+        else:
+            sys.stdin = StringIO(code)
+        tree = ast.parse(code)
+        checker = BuiltinsChecker(tree, 'stdin')
+        ret = [c for c in checker.run()]
+        sys.stdin = stdin_
+        self.assertEqual(
+            len(ret),
+            1
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi, and thanks for your work on this plugin :)

I've noticed that v0.3 breaks in stdin handling due to a wrong argument passed to ast.parse() (a list instead of a string). I've fixed that and added a test, that passes on all python versions on Travis.

Please let me know if you want me to make changes to this PR.

Thanks again :)