### PR TITLE
duplicate list before modifying it

### DIFF
--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -111,7 +111,7 @@ class BuiltinsChecker(object):
         if type(statement.__flake8_builtins_parent) is ast.ClassDef:
             msg = self.class_attribute_msg
 
-        stack = statement.targets
+        stack = list(statement.targets)
         while stack:
             item = stack.pop()
             if isinstance(item, (ast.Tuple, ast.List)):


### PR DESCRIPTION
Fixes #34. Like also addresses #36 (as mentioned in one of the comments).

This regression was introduced in #32: https://github.com/gforcada/flake8-builtins/commit/89df9682796ad96cd60991661aa3e6da62dab035#diff-fef87cfd8dd8ac2667a6ba1e5a368dc1R116

If this gets merged can you please consider doing a patch release soon since this affects a lot of users and in the current state the plugin isn't usable. Thank you.