### PR TITLE
Bump pycodestyle version up to 2.4.0 and flake8 up to 3.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 .
 configparser==3.5.0
 enum34==1.1.6
-flake8==3.5.0
+flake8==3.6.0
 mccabe==0.6.1
-pycodestyle==2.3.1
+pycodestyle==2.4.0
 pyflakes==1.6.0


### PR DESCRIPTION
I had some conflicts with other flake8 plugins due to outdated version of `pycodestyle`, hope this super tiny PR is going to help.