### PR TITLE
Fix #75 disable A003 by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,22 @@ Requirements
 - Python 3.7, 3.8, 3.9, 3.10, 3.11, and pypy3
 - flake8
 
+Rules
+-----
+
+A001:
+  variable is shadowing a python builtin
+
+A002:
+  argument is shadowing a python builtin
+
+A003 [1]_:
+  class attribute is shadowing a python builtin
+
+.. [1] This rule is disabled by default. You can add it to the `extend-select
+       <https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-extend-select>`_
+       section in your flake8 config file to enable it.
+
 License
 -------
 GPL 2.0

--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -39,6 +39,8 @@ class BuiltinsChecker:
             comma_separated_list=True,
             help='A comma separated list of builtins to skip checking',
         )
+        if "A003" not in option_manager.extended_default_ignore:
+            option_manager.extend_default_ignore(["A003"])
 
     @classmethod
     def parse_options(cls, options):


### PR DESCRIPTION
This PR will disable A003 by default. When the next version of flake8 is released, the user can add A003 to `extend-select` to enable it.