### PR TITLE
Whitelist the copyright builtin by default

### DIFF
--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -9,6 +9,7 @@ WHITE_LIST = {
     '__name__',
     '__doc__',
     'credits',
+    'copyright',
     '_',
 }
 


### PR DESCRIPTION
If we're whitelist `credits` by default, I think it makes sense to also whitelist `copyright` by default.