### PR TITLE
chore: remove unnecessary license clause

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
 ]
 description = "Check for python builtins being used as variables or parameters"
 keywords = ["pep8", "flake8", "python", ]
-license = {file = "LICENSE"}
 readme = "README.rst"
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
Setting this field makes the entire GPLv2 license text appear when viewing the package metadata, e.g. with `pip show flake8-builtins`.

I feel this is a bit too verbose, and unnecessary.

As described in the [python packaging guide] it is not necessary to specify this field when using a standard license. Actually, this might be more confusing to users, as they may avoid the package if a modified license is implied:

> If you are using a standard, well-known license, it is not necessary
> to use this field. Instead, you should one of the classifiers starting
> with License ::. (As a general rule, it is a good idea to use a
> standard, well-known license, both to avoid confusion and because some
> organizations avoid software whose license is unapproved.)

Since this package already uses [the 'License' classifier](https://github.com/asfaltboy/flake8-builtins/blob/9639ae4d7e36bad57c73f3ace060ebc8c2f24091/pyproject.toml?plain=1#L20), I think removing this from `pyproject.toml` should remove it from the metadata when uploading to pypi with hatchling.

[python packaging guide]: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license