### PR TITLE
Introduce A006 for lambda shadowing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,11 @@
 Changelog
 =========
 
-2.3.1 (unreleased)
+2.3.1 (2024-04-01)
 ------------------
 
-- Nothing changed yet.
+- Add rule for lambda argument shadowing (`A006`).
+  [cielavenir]
 
 
 2.3.0 (2024-03-29)

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,9 @@ A003:
 A004:
   An import statement is shadowing a Python builtin.
 
+A005:
+  A lambda argument is shadowing a Python builtin.
+
 License
 -------
 GPL 2.0

--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -58,7 +58,7 @@ class BuiltinsChecker:
             for child in ast.iter_child_nodes(statement):
                 child.__flake8_builtins_parent = statement
 
-        function_nodes = [ast.FunctionDef]
+        function_nodes = [ast.FunctionDef, ast.Lambda]
         if getattr(ast, 'AsyncFunctionDef', None):
             function_nodes.append(ast.AsyncFunctionDef)
         function_nodes = tuple(function_nodes)
@@ -136,7 +136,7 @@ class BuiltinsChecker:
                     stack.extend(list(item.value.elts))
 
     def check_function_definition(self, statement):
-        if statement.name in self.names:
+        if not isinstance(statement, ast.Lambda) and statement.name in self.names:
             msg = self.assign_msg
             if type(statement.__flake8_builtins_parent) is ast.ClassDef:
                 msg = self.class_attribute_msg

--- a/run_tests.py
+++ b/run_tests.py
@@ -142,7 +142,7 @@ def test_argument_message():
 
 def test_lambda_argument_message():
     source = 'takefirst = lambda list: list[0]'
-    check_code(source, 'A002')
+    check_code(source, 'A005')
 
 
 def test_keyword_argument_message():
@@ -171,6 +171,15 @@ def test_posonly_argument_message():
     """
     check_code(source, 'A002')
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason='This syntax is only valid in Python 3.8+',
+)
+def test_lambda_posonly_argument_message():
+    source = """
+    takefirst = lambda list, /: list[0]
+    """
+    check_code(source, 'A005')
 
 def test_no_error():
     source = """def bla(first):\n    b = 4"""

--- a/run_tests.py
+++ b/run_tests.py
@@ -140,6 +140,11 @@ def test_argument_message():
     check_code(source, 'A002')
 
 
+def test_lambda_argument_message():
+    source = 'takefirst = lambda list: list[0]'
+    check_code(source, 'A002')
+
+
 def test_keyword_argument_message():
     source = """
     def bla(dict=3):

--- a/run_tests.py
+++ b/run_tests.py
@@ -158,7 +158,7 @@ def test_argument_message():
 
 def test_lambda_argument_message():
     source = 'takefirst = lambda list: list[0]'
-    check_code(source, 'A005')
+    check_code(source, 'A006')
 
 
 def test_keyword_argument_message():
@@ -195,7 +195,7 @@ def test_lambda_posonly_argument_message():
     source = """
     takefirst = lambda list, /: list[0]
     """
-    check_code(source, 'A005')
+    check_code(source, 'A006')
 
 def test_no_error():
     source = """def bla(first):\n    b = 4"""


### PR DESCRIPTION
I added this to run_tests.py:

```
def test_lambda_argument_message():
    source = 'takefirst = lambda list: list[0]'
    check_code(source, 'A002')
```

Then I see this:

```
>       assert len(return_statements) == len(expected_codes)
E       AssertionError: assert 0 == 1
E        +  where 0 = len([])
E        +  and   1 = len(['A002'])
```

This MR tries to fix it.

Reproduced in main/Python3, 1.5/Python3 and 1.5/Python2.

/cc @felixvd @ntohge