### PR TITLE
feat(A005): support detecting a shadowing folder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support detecting a shadowing folder as module name (as part of `A005`).
+  [asfaltboy]
 
 
 2.4.0 (2024-04-01)

--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -293,7 +293,10 @@ class BuiltinsChecker:
         if not self.module_names:
             return
         path = Path(filename)
-        module_name = path.name.removesuffix('.py')
+        if path.name == '__init__.py':
+            module_name = path.parent.name
+        else:
+            module_name = path.name.removesuffix('.py')
         if module_name in self.module_names:
             yield self.error(
                 None,

--- a/run_tests.py
+++ b/run_tests.py
@@ -510,6 +510,7 @@ def test_tuple_unpacking():
 def test_module_name():
     source = ''
     check_code(source, expected_codes='A005', filename='./temp/logging.py')
+    check_code(source, expected_codes='A005', filename='./temp/typing/__init__.py')
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Package directories that are named the same as built-in modules can also cause the issue. This should handle both:

Given a directory with these files:
```bash
❯ eza -T temp/
drwxr-xr-x - asfaltboy  8 Apr 13:44  temp
drwxr-xr-x - asfaltboy  8 Apr 13:44 ├──  typing
.rw-r--r-- 0 asfaltboy  8 Apr 13:44 │  └──  __init__.py
.rw-r--r-- 0 asfaltboy 20 Feb 11:22 ├──  __init__.py
.rw-r--r-- 9 asfaltboy 19 Feb 14:57 └──  logging.py
```

Running flake8 with the plugin on this PR's branch, results in:

```
❯ flake8 ./temp/
./temp/logging.py:0:1: A005 the module is shadowing a Python builtin module "logging"
./temp/typing/__init__.py:0:1: A005 the module is shadowing a Python builtin module "typing"
```

fix #124