### PR TITLE
Add support for TypedDict

### DIFF
--- a/flake8_builtins.py
+++ b/flake8_builtins.py
@@ -140,7 +140,9 @@ class BuiltinsChecker:
 
     def check_assignment(self, statement):
         msg = self.assign_msg
-        if type(statement.__flake8_builtins_parent) is ast.ClassDef:
+        if isinstance(statement.__flake8_builtins_parent, ast.ClassDef):
+            if "TypedDict" in {a.id for a in statement.__flake8_builtins_parent.bases if isinstance(a, ast.Name)}:
+                return
             msg = self.class_attribute_msg
 
         if isinstance(statement, ast.Assign):

--- a/run_tests.py
+++ b/run_tests.py
@@ -529,3 +529,77 @@ def test_module_name_ignore_module():
 def test_module_name_not_builtin():
     source = ''
     check_code(source, filename='log_config')
+
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason='Typed dicts are introduced in Python 3.9',
+)
+def test_typed_dicts_dont_shadow_builtins():
+    source = """
+    from typing import Any, TypedDict
+
+
+    class PaginatedResponse(TypedDict):
+        count: int
+        next: str
+        prev: str
+        data: list[Any]
+    """
+    check_code(source)
+
+
+@pytest.mark.xfail(reason="N-deep inheritence not supported")
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason='Typed dicts are introduced in Python 3.9',
+)
+def test_inherited_typed_dicts_dont_shadow_builtins():
+    source = """
+    from typing import Any, TypedDict
+
+
+    class ApiResponseDict(TypedDict):
+        status: int
+        okay: bool
+
+
+    class PaginatedResponse(ApiResponseDict):
+        count: int
+        next: str
+        prev: str
+        data: list[Any]
+    """
+    check_code(source)
+
+
+@pytest.mark.xfail(reason="N-deep inheritence not supported")
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason='Typed dicts are introduced in Python 3.9',
+)
+def test_n_deep_inherited_typed_dicts_dont_shadow_builtins():
+    source = """
+    from typing import Any, TypedDict
+
+
+    class ApiResponseDict(TypedDict):
+        status: int
+        okay: bool
+
+
+    class Something(ApiResponseDict):
+        okay: int
+
+
+    class SomethingElse(Something):
+        is_an_oof: bool
+
+    class PaginatedResponse(SomethingElse):
+        count: int
+        next: str
+        prev: str
+        data: list[Any]
+    """
+    check_code(source)


### PR DESCRIPTION
> [!INFO]
> This PR is to related to resolving issue #127

`TypedDicts` are used only within the type system for analysis and
represent the keys of a dictionary and their corresponding types.
They are a useful tool when providing type hints of a JSON payload or
similar.

For example the following code snippet will raise a false-positive alert
from this flake8 plug-in:
```python
class ApiPage(TypedDict):
  url: str
  next: str
  data: list[dict[str, Any]]
```

This is because a `TypedDict` is analysed as if it was a standard class.
Since it is only used in the type system it is safe to ignore anything
that inherits from `TypedDict` in this plugin.


Currently, this PR has the limitation that it does not handle inheritances.
There is also a foreseen issue where false positives will still occur if
the _shadowing_ variable is in a class that inherits from a `TypedDict` defined
in another class.
